### PR TITLE
Termination vs truncation

### DIFF
--- a/src/ajax/agents/AVG/AVG.py
+++ b/src/ajax/agents/AVG/AVG.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
         chunk_size=chunk_size,
         horizon=10_000,
     )
-    env_id = "halfcheetah"
+    env_id = "Pendulum-v1"
     sac_agent = AVG(env_id=env_id, learning_starts=int(1e4))
     sac_agent.train(
         seed=list(range(n_seeds)),

--- a/src/ajax/agents/sac/sac.py
+++ b/src/ajax/agents/sac/sac.py
@@ -71,7 +71,7 @@ class SAC:
         env, env_params, env_id, continuous = prepare_env(
             env_id,
             env_params=env_params,
-            normalize_obs=True,
+            normalize_obs=False,
             normalize_reward=False,
             num_envs=num_envs,
             gamma=gamma,
@@ -181,10 +181,10 @@ class SAC:
 
 if __name__ == "__main__":
     n_seeds = 1
-    log_frequency = 20_000
+    log_frequency = 5_000
     chunk_size = 1000
     logging_config = LoggingConfig(
-        "match_SAC_reproducibility",
+        "match_SAC_reproducibility_truncated",
         "test",
         config={
             "debug": False,

--- a/src/ajax/agents/sac/train_sac.py
+++ b/src/ajax/agents/sac/train_sac.py
@@ -577,12 +577,15 @@ def update_agent(
     # Sample buffer
 
     sample_key, rng = jax.random.split(agent_state.rng)
-    observations, dones, next_observations, rewards, actions = get_batch_from_buffer(
-        buffer,
-        agent_state.collector_state.buffer_state,
-        sample_key,
+    observations, terminated, truncated, next_observations, rewards, actions = (
+        get_batch_from_buffer(
+            buffer,
+            agent_state.collector_state.buffer_state,
+            sample_key,
+        )
     )
     agent_state = agent_state.replace(rng=rng)
+    dones = jnp.logical_or(terminated, truncated)
 
     # Update Q functions
     def critic_update_step(carry, _):

--- a/src/ajax/buffers/utils.py
+++ b/src/ajax/buffers/utils.py
@@ -49,7 +49,8 @@ def init_buffer(
             "obs": obsv,  # Single observation (shape: [observation_size])
             "action": action,  # Single action (shape: [action_size])
             "reward": reward,  # Single reward (shape: [1])
-            "done": done,  # Single done flag (shape: [1])
+            "terminated": done,  # Single done flag (shape: [1])
+            "truncated": done,  # Single done flag (shape: [1])
             "next_obs": obsv,  # Next observation (same shape as 'obs')
         },
     )
@@ -74,6 +75,7 @@ def get_batch_from_buffer(buffer, buffer_state, key):
     act = batch.first["action"]
     rew = batch.first["reward"]
     next_obs = batch.first["next_obs"]
-    done = batch.first["done"]
+    terminated = batch.first["terminated"]
+    truncated = batch.first["truncated"]
 
-    return obs, done, next_obs, rew, act
+    return obs, terminated, truncated, next_obs, rew, act

--- a/src/ajax/environments/interaction.py
+++ b/src/ajax/environments/interaction.py
@@ -89,9 +89,9 @@ def step_env(
             env.step,
             in_axes=(0, 0, 0, None),
         )(rng, state, action, env_params)
-        done = jnp.float_(done)
-        truncated = done
-        terminated = done
+        truncated = env_state.time >= env_params.max_steps_in_episode  # type: ignore[union-attr]
+        terminated = done * (1 - truncated)
+        terminated, truncated = jnp.float_(terminated), jnp.float_(truncated)
     elif mode == "brax":  # ✅ no vmap for brax
         env_state = env.step(state, action)
         obsv, reward, done, info = (

--- a/src/ajax/state.py
+++ b/src/ajax/state.py
@@ -27,7 +27,8 @@ class CollectorState:
     rng: jax.Array
     env_state: EnvStateType
     last_obs: jnp.ndarray
-    last_done: jnp.ndarray
+    last_terminated: jnp.ndarray
+    last_truncated: jnp.ndarray
     num_update: int = 0
     timestep: int = 0
     average_reward: float = 0.0

--- a/tests/agents/AVG/test_train_AVG.py
+++ b/tests/agents/AVG/test_train_AVG.py
@@ -87,7 +87,8 @@ def avg_state(env_config):
         action=jnp.ones((env_config.num_envs, *action_shape)),
         next_obs=jnp.ones((env_config.num_envs, *obs_shape)),
         reward=jnp.ones((env_config.num_envs, 1)),
-        done=jnp.ones((env_config.num_envs, 1)),
+        terminated=jnp.ones((env_config.num_envs, 1)),
+        truncated=jnp.ones((env_config.num_envs, 1)),
     )
     collector_state = avg_state.collector_state.replace(rollout=transition)
     avg_state = avg_state.replace(collector_state=collector_state)

--- a/tests/buffers/test_buffers_utils.py
+++ b/tests/buffers/test_buffers_utils.py
@@ -57,7 +57,7 @@ def test_init_buffer(buffer_fixture, buffer_state_fixture):
     expected_buffer_size = buffer_size // num_envs
 
     # Check the buffer state structure
-    for key in ["obs", "action", "reward", "done", "next_obs"]:
+    for key in ["obs", "action", "reward", "terminated", "truncated", "next_obs"]:
         assert key in buffer_state.experience.keys()
 
     # Validate shapes
@@ -76,7 +76,12 @@ def test_init_buffer(buffer_fixture, buffer_state_fixture):
         expected_buffer_size,
         1,
     )
-    assert buffer_state.experience["done"].shape == (
+    assert buffer_state.experience["terminated"].shape == (
+        env_args.num_envs,
+        expected_buffer_size,
+        1,
+    )
+    assert buffer_state.experience["truncated"].shape == (
         env_args.num_envs,
         expected_buffer_size,
         1,
@@ -98,13 +103,14 @@ def test_get_batch_from_buffer(buffer_state_fixture):
     key = jax.random.PRNGKey(0)
 
     # Sample a batch from the buffer
-    obs, done, next_obs, reward, action = get_batch_from_buffer(
+    obs, terminated, truncated, next_obs, reward, action = get_batch_from_buffer(
         buffer, buffer_state, key
     )
 
     # Validate shapes of the sampled batch
     assert obs.shape == (batch_size, *observation_shape)
-    assert done.shape == (batch_size, 1)
+    assert terminated.shape == (batch_size, 1)
+    assert truncated.shape == (batch_size, 1)
     assert next_obs.shape == (batch_size, *observation_shape)
     assert reward.shape == (batch_size, 1)
     assert action.shape == (batch_size, *action_shape)

--- a/tests/environments/test_wrappers.py
+++ b/tests/environments/test_wrappers.py
@@ -30,14 +30,15 @@ class MockGymnaxEnv:
 
     def reset(self, key, params=None):
         obs = jnp.array([1.0, -1.0])
-        state = {"step_count": 0}
+        state = MockGymnaxState(step_count=0)
         return obs, state
 
     def step(self, key, state, action, params=None):
         obs = jnp.array([1.0, -1.0])
         reward = 2.0
-        done = state["step_count"] >= 5
+        done = state.step_count >= 5
         info = {}
+        state = MockGymnaxState(step_count=state.step_count + 1)
         return obs, state, reward, done, info
 
 
@@ -66,6 +67,13 @@ class MockBraxEnv:
             pipeline_state=None,
             info={},
         )
+
+
+@struct.dataclass
+class MockGymnaxState:
+    """Mock Brax state for testing."""
+
+    step_count: jnp.ndarray
 
 
 @struct.dataclass


### PR DESCRIPTION
Differenciate termination (reaching a terminal state) to truncation (stopping after a given amount of time) in environment interaction to properly handle bootstrap in value predictions (value of a terminal state should be 0, value of a truncated state should not). 