### PR TITLE
remove next obs from buffer and rebuild it later

### DIFF
--- a/src/ajax/buffers/utils.py
+++ b/src/ajax/buffers/utils.py
@@ -51,7 +51,6 @@ def init_buffer(
             "reward": reward,  # Single reward (shape: [1])
             "terminated": done,  # Single done flag (shape: [1])
             "truncated": done,  # Single done flag (shape: [1])
-            "next_obs": obsv,  # Next observation (same shape as 'obs')
         },
     )
 
@@ -74,7 +73,7 @@ def get_batch_from_buffer(buffer, buffer_state, key):
     obs = batch.first["obs"]
     act = batch.first["action"]
     rew = batch.first["reward"]
-    next_obs = batch.first["next_obs"]
+    next_obs = batch.second["obs"]
     terminated = batch.first["terminated"]
     truncated = batch.first["truncated"]
 

--- a/src/ajax/environments/interaction.py
+++ b/src/ajax/environments/interaction.py
@@ -290,7 +290,6 @@ def collect_experience(
         "reward": reward[:, None],
         "terminated": agent_state.collector_state.last_terminated[:, None],
         "truncated": agent_state.collector_state.last_truncated[:, None],
-        "next_obs": obsv,
     }
     if buffer is not None:
         buffer_state = buffer.add(
@@ -298,6 +297,9 @@ def collect_experience(
             _transition,
         )
     else:
+        _transition.update(
+            {"next_obs": obsv}
+        )  # not included if using buffer to reduce weight, as flashbax can rebuild it.
         transition = Transition(**_transition)
 
     new_collector_state = agent_state.collector_state.replace(

--- a/tests/buffers/test_buffers_utils.py
+++ b/tests/buffers/test_buffers_utils.py
@@ -57,7 +57,7 @@ def test_init_buffer(buffer_fixture, buffer_state_fixture):
     expected_buffer_size = buffer_size // num_envs
 
     # Check the buffer state structure
-    for key in ["obs", "action", "reward", "terminated", "truncated", "next_obs"]:
+    for key in ["obs", "action", "reward", "terminated", "truncated"]:
         assert key in buffer_state.experience.keys()
 
     # Validate shapes
@@ -85,11 +85,6 @@ def test_init_buffer(buffer_fixture, buffer_state_fixture):
         env_args.num_envs,
         expected_buffer_size,
         1,
-    )
-    assert buffer_state.experience["next_obs"].shape == (
-        env_args.num_envs,
-        expected_buffer_size,
-        *observation_shape,
     )
 
 


### PR DESCRIPTION
Save memory by removing next_obs from buffer as it is a duplicate of memory already in the buffer. This should save memory usage.