### PR TITLE
Fix reward accumulation order in environment evaluation

### DIFF
--- a/src/ajax/evaluate.py
+++ b/src/ajax/evaluate.py
@@ -92,9 +92,8 @@ def evaluate(
         still_running = 1 - done  # only count unfinished envs
         step_count += still_running.mean()
         entropy_sum += (entropy.mean() * still_running).mean()
+        rewards += new_rewards * still_running
         done = done | jnp.int8(new_done)
-
-        rewards += new_rewards * (1 - done)
         return rewards, rng, obs, done, state, entropy_sum, step_count
 
     def env_not_done(carry):


### PR DESCRIPTION
The previous implementation updated the done flags before accumulating rewards:
```python
done = done | jnp.int8(new_done)
rewards += new_rewards * (1 - done)
```

This meant environments terminated in the current step wouldn't receive their final reward. The fix reverses this order, ensuring all environments receive rewards for the transition that leads to termination.