### PR TITLE
SAC: argmax-LCB gate variant + p_expert_max telemetry

### DIFF
--- a/src/ajax/agents/SAC/SAC.py
+++ b/src/ajax/agents/SAC/SAC.py
@@ -118,6 +118,7 @@ class SAC(ActorCritic):
         exploration_argmax: bool = False,
         # Quality-aware (LCB) gate
         exploration_lcb: bool = False,
+        exploration_argmax_lcb: bool = False,
         exploration_thompson: bool = False,
         lcb_beta_init: float = 1.0,
         lcb_beta_decay_k: float = 2.0,
@@ -354,6 +355,7 @@ class SAC(ActorCritic):
         self.fixed_exploration_prob = fixed_exploration_prob
         self.exploration_argmax = exploration_argmax
         self.exploration_lcb = exploration_lcb
+        self.exploration_argmax_lcb = exploration_argmax_lcb
         self.exploration_thompson = exploration_thompson
         self.lcb_beta_init = lcb_beta_init
         self.lcb_beta_decay_k = lcb_beta_decay_k
@@ -445,6 +447,7 @@ class SAC(ActorCritic):
             fixed_exploration_prob=self.fixed_exploration_prob,
             exploration_argmax=self.exploration_argmax,
             exploration_lcb=self.exploration_lcb,
+            exploration_argmax_lcb=self.exploration_argmax_lcb,
             exploration_thompson=self.exploration_thompson,
             expert_fraction=self.expert_fraction,
             epsilon_floor=self.epsilon_floor,

--- a/src/ajax/agents/SAC/train_SAC.py
+++ b/src/ajax/agents/SAC/train_SAC.py
@@ -125,7 +125,11 @@ class ActionPipelineResult(NamedTuple):
 
 
 def _apply_lcb_gate(
-    score_e, score_p, rng, lcb_temperature, argmax,
+    score_e,
+    score_p,
+    rng,
+    lcb_temperature,
+    argmax,
 ):
     """Pick LCB gate: argmax (deterministic) or softmax (default)."""
     if argmax:
@@ -457,8 +461,11 @@ def make_action_pipeline(
                     beta_eff,
                 )
                 use_expert_edge, rng = _apply_lcb_gate(
-                    score_e, score_p, rng,
-                    lcb_temperature, exploration_argmax_lcb,
+                    score_e,
+                    score_p,
+                    rng,
+                    lcb_temperature,
+                    exploration_argmax_lcb,
                 )
                 # gap kept for diagnostic logging compat
                 gap = score_e - score_p

--- a/src/ajax/agents/SAC/train_SAC.py
+++ b/src/ajax/agents/SAC/train_SAC.py
@@ -124,6 +124,15 @@ class ActionPipelineResult(NamedTuple):
     a_expert: Optional[jax.Array] = None
 
 
+def _apply_lcb_gate(
+    score_e, score_p, rng, lcb_temperature, argmax,
+):
+    """Pick LCB gate: argmax (deterministic) or softmax (default)."""
+    if argmax:
+        return edge_lcb_argmax_gate(score_e, score_p, rng)
+    return edge_lcb_gate(score_e, score_p, rng, lcb_temperature)
+
+
 def make_action_pipeline(
     expert_policy,
     recurrent,
@@ -447,19 +456,10 @@ def make_action_pipeline(
                     edge_critic_params,
                     beta_eff,
                 )
-                if exploration_argmax_lcb:
-                    # Argmax-LCB corner of the 2x2: deterministic gate
-                    # over LCB scores. Skips the softmax sampling.
-                    use_expert_edge, rng = edge_lcb_argmax_gate(
-                        score_e, score_p, rng,
-                    )
-                else:
-                    use_expert_edge, rng = edge_lcb_gate(
-                        score_e,
-                        score_p,
-                        rng,
-                        lcb_temperature,
-                    )
+                use_expert_edge, rng = _apply_lcb_gate(
+                    score_e, score_p, rng,
+                    lcb_temperature, exploration_argmax_lcb,
+                )
                 # gap kept for diagnostic logging compat
                 gap = score_e - score_p
                 # Live LCB telemetry (mean over batch).

--- a/src/ajax/agents/SAC/train_SAC.py
+++ b/src/ajax/agents/SAC/train_SAC.py
@@ -62,6 +62,7 @@ from ajax.modules.exploration import (
     edge_compute_thompson_stats,
     edge_compute_value_gap,
     edge_fixed_gate,
+    edge_lcb_argmax_gate,
     edge_lcb_gate,
     edge_thompson_gate,
 )
@@ -114,6 +115,7 @@ class ActionPipelineResult(NamedTuple):
     q_advantage: Optional[jax.Array] = None  # mean(mu_actor - mu_expert)
     critic_sigma_actor: Optional[jax.Array] = None  # mean(sigma_actor)
     critic_sigma_expert: Optional[jax.Array] = None  # mean(sigma_expert)
+    p_expert_max: Optional[jax.Array] = None  # max(p_t) of LCB softmax gate
     # Expert action computed at this step with the correct (stateful) expert
     # internal state. Stored in the Transition so the residual-RL actor
     # loss can read it back instead of recomputing the expert with a fresh
@@ -139,6 +141,10 @@ def make_action_pipeline(
     fixed_exploration_prob=0.5,
     # Quality-aware (LCB) gate — alternative to argmax/boltzmann/fixed
     exploration_lcb=False,
+    # Variant of the LCB path that swaps the softmax gate for a
+    # deterministic argmax (score_e > score_p) while keeping LCB
+    # scoring. Populates the (argmax, LCB) corner of the 2x2 ablation.
+    exploration_argmax_lcb=False,
     exploration_thompson=False,
     lcb_beta_init=1.0,
     lcb_beta_decay_k=2.0,
@@ -210,6 +216,7 @@ def make_action_pipeline(
         _diag_q_advantage = jnp.nan
         _diag_sigma_actor = jnp.nan
         _diag_sigma_expert = jnp.nan
+        _diag_p_expert_max = jnp.nan
 
         # --- Gain-policy short-circuit ---
         if gain_policy_mode:
@@ -440,18 +447,34 @@ def make_action_pipeline(
                     edge_critic_params,
                     beta_eff,
                 )
-                use_expert_edge, rng = edge_lcb_gate(
-                    score_e,
-                    score_p,
-                    rng,
-                    lcb_temperature,
-                )
+                if exploration_argmax_lcb:
+                    # Argmax-LCB corner of the 2x2: deterministic gate
+                    # over LCB scores. Skips the softmax sampling.
+                    use_expert_edge, rng = edge_lcb_argmax_gate(
+                        score_e, score_p, rng,
+                    )
+                else:
+                    use_expert_edge, rng = edge_lcb_gate(
+                        score_e,
+                        score_p,
+                        rng,
+                        lcb_temperature,
+                    )
                 # gap kept for diagnostic logging compat
                 gap = score_e - score_p
                 # Live LCB telemetry (mean over batch).
                 _diag_q_advantage = jnp.mean(_mu_p - _mu_e)
                 _diag_sigma_actor = jnp.mean(_sigma_p)
                 _diag_sigma_expert = jnp.mean(_sigma_e)
+                # Coverage Lemma diagnostic: max(p_expert) over the
+                # collection batch. With softmax gate, this is
+                # max sigmoid((score_e - score_p) / tau); with the
+                # argmax_lcb variant the empirical max is in {0, 1}.
+                _diag_p_expert_max = jnp.max(
+                    jax.nn.sigmoid(
+                        (score_e - score_p) / jnp.maximum(lcb_temperature, 1e-6)
+                    )
+                )
             else:
                 gap, q_policy = edge_compute_value_gap(
                     obs_for_edge,
@@ -554,6 +577,7 @@ def make_action_pipeline(
             q_advantage=_diag_q_advantage,
             critic_sigma_actor=_diag_sigma_actor,
             critic_sigma_expert=_diag_sigma_expert,
+            p_expert_max=_diag_p_expert_max,
             buffer_action=_buffer_action_field,
             a_expert=expert_action,
         )
@@ -2049,6 +2073,9 @@ def training_iteration(
                 live_critic_sigma_expert=jnp.atleast_1d(
                     agent_state.collector_state.last_critic_sigma_expert
                 ),
+                live_p_expert_max=jnp.atleast_1d(
+                    agent_state.collector_state.last_p_expert_max
+                ),
             ),
             # Override the zeros from update_agent with the actual refresh diagnostics
             phi_refresh=PhiRefreshAuxiliaries(
@@ -2193,6 +2220,7 @@ def make_train(
     exploration_argmax: bool = False,
     # Quality-aware (LCB) gate
     exploration_lcb: bool = False,
+    exploration_argmax_lcb: bool = False,
     exploration_thompson: bool = False,
     lcb_beta_init: float = 1.0,
     lcb_beta_decay_k: float = 2.0,
@@ -2467,6 +2495,7 @@ def make_train(
                 exploration_argmax=exploration_argmax,
                 fixed_exploration_prob=fixed_exploration_prob,
                 exploration_lcb=exploration_lcb,
+                exploration_argmax_lcb=exploration_argmax_lcb,
                 lcb_asymmetric=lcb_asymmetric,
                 exploration_thompson=exploration_thompson,
                 expert_fraction=expert_fraction,

--- a/src/ajax/environments/interaction.py
+++ b/src/ajax/environments/interaction.py
@@ -618,6 +618,7 @@ def collect_experience(
         _live_q_advantage = getattr(result, "q_advantage", None)
         _live_sigma_actor = getattr(result, "critic_sigma_actor", None)
         _live_sigma_expert = getattr(result, "critic_sigma_expert", None)
+        _live_p_expert_max = getattr(result, "p_expert_max", None)
         _a_expert = getattr(result, "a_expert", None)
     else:
         new_expert_state = None
@@ -625,6 +626,7 @@ def collect_experience(
         _live_q_advantage = None
         _live_sigma_actor = None
         _live_sigma_expert = None
+        _live_p_expert_max = None
         _a_expert = None
         # Vanilla: uniform during warmup, policy action after
         action, log_probs = get_action_and_log_probs(
@@ -783,6 +785,8 @@ def collect_experience(
         _gate_diag_updates["last_critic_sigma_actor"] = _live_sigma_actor
     if _live_sigma_expert is not None:
         _gate_diag_updates["last_critic_sigma_expert"] = _live_sigma_expert
+    if _live_p_expert_max is not None:
+        _gate_diag_updates["last_p_expert_max"] = _live_p_expert_max
 
     # Per-env step_in_episode counter for JSRL curriculum: increment
     # by 1 each step, reset to 0 on episode end (terminated|truncated).

--- a/src/ajax/modules/exploration.py
+++ b/src/ajax/modules/exploration.py
@@ -230,6 +230,23 @@ def edge_compute_asym_scores(
     return score_e, score_p, q_min_p, mu_p, mu_e, sigma_p, sigma_e
 
 
+def edge_lcb_argmax_gate(
+    score_expert: jax.Array,
+    score_policy: jax.Array,
+    rng: jax.Array,
+) -> Tuple[jax.Array, jax.Array]:
+    """Deterministic argmax gate over LCB scores.
+
+    use_expert = score_e > score_p.
+
+    Compared to ``edge_lcb_gate`` (softmax), this collapses the gate to
+    a hard threshold while preserving the LCB scoring (mu - beta*sigma)
+    so the (gating form, scoring rule) ablation can vary one axis at
+    a time. Used by the ``argmax_lcb`` corner of the 2x2.
+    """
+    return score_expert > score_policy, rng
+
+
 def edge_lcb_gate(
     score_expert: jax.Array,
     score_policy: jax.Array,
@@ -419,6 +436,7 @@ class EDGEAuxiliaries:
     live_q_advantage: jax.Array  # mean(mu_actor - mu_expert), LCB/Thompson only
     live_critic_sigma_actor: jax.Array
     live_critic_sigma_expert: jax.Array
+    live_p_expert_max: jax.Array  # max(p_t) of LCB softmax gate, NaN otherwise
 
 
 def compute_edge_diagnostics(
@@ -440,4 +458,5 @@ def compute_edge_diagnostics(
         live_q_advantage=jnp.array([jnp.nan]),
         live_critic_sigma_actor=jnp.array([jnp.nan]),
         live_critic_sigma_expert=jnp.array([jnp.nan]),
+        live_p_expert_max=jnp.array([jnp.nan]),
     )

--- a/src/ajax/state.py
+++ b/src/ajax/state.py
@@ -184,6 +184,11 @@ class CollectorState:
     last_q_advantage: float = jnp.nan
     last_critic_sigma_actor: float = jnp.nan
     last_critic_sigma_expert: float = jnp.nan
+    # Empirical max of the LCB gate's expert-arm probability over the
+    # last collection batch. Diagnostic for the Coverage Lemma's gap-
+    # bound hypothesis: a uniform p_max < 1 over training implies the
+    # bounded-gap precondition holds on the visited support.
+    last_p_expert_max: float = jnp.nan
     # Per-env step counter within the current episode. Incremented on
     # every env step, reset to 0 on done. Used by jsrl_curriculum to
     # decide whether the expert acts (step_in_episode < H_t) or the


### PR DESCRIPTION
- exploration.py: add edge_lcb_argmax_gate (deterministic gate over LCB scores) so the (gating form, scoring rule) 2x2 ablation can vary one axis at a time.
- SAC.py / train_SAC.py: thread exploration_argmax_lcb through the action pipeline; pick the new gate when the flag is set, keep softmax otherwise.
- train_SAC.py / state.py / exploration.py: log live_p_expert_max (max sigmoid((score_e - score_p) / tau)) per collection batch as a Coverage Lemma diagnostic.
- interaction.py: forward the new live_p_expert_max field through collect_experience.